### PR TITLE
Feature/instruction annotation

### DIFF
--- a/lib/process-template-annotation.js
+++ b/lib/process-template-annotation.js
@@ -52,6 +52,9 @@ export const parseSelectTemplateBindings = (bindings) => {
         ...(binding.variableCodelist && {
           codelist: binding.variableCodelist.value,
         }),
+        ...(binding.annotatedTemplate && {
+          annotatedTemplate: binding.annotatedTemplate.value,
+        }),
       };
 
       data[uri].variables.push(variable);
@@ -62,8 +65,8 @@ export const parseSelectTemplateBindings = (bindings) => {
 };
 
 /**
- * Generates an array of annotated templates. 
- * 
+ * Generates an array of annotated templates.
+ *
  * @param {Template[]} templates - The templates to be annotated.
  * @returns {{ uri: string, annotated: string }[]} An array containing the annotated templates.
  */
@@ -87,6 +90,7 @@ export const applyTemplateMappings = (basicTemplate, variables) => {
   let annotatedTemplate = basicTemplate;
 
   const templateGenerators = {
+    instruction: (variable) => variable.annotatedTemplate,
     codelist: (variable) =>
       generateCodelistTemplate({
         ...variable,
@@ -101,8 +105,6 @@ export const applyTemplateMappings = (basicTemplate, variables) => {
     default: generateTextTemplate,
   };
   for (const variable of variables) {
-    if (variable.type === "instruction") continue;
-
     const regex = new RegExp(`\\\${${variable.value}}`, "g");
     const generator =
       templateGenerators[variable.type] || templateGenerators.default;

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -159,6 +159,12 @@ export const deleteAnnotated = async (uris) => {
   await update(deleteQuery);
 };
 
+/**
+ * Fetches all the template uris linked to a array of given uris
+ *
+ * @param {string[]} uris - The array containing the uris of the templates.
+ * @returns {string[]} An array of all the uris of the linked templates.
+ */
 export const getLinkedTemplates = async (templateUris) => {
   if (templateUris && !Array.isArray(templateUris)) {
     throw new Error("templateUris must be an array of strings.");

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -44,7 +44,7 @@ export const getTemplatesAndVariables = async (templateUris) => {
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   
-    SELECT DISTINCT ?uri ?templateValue ?variableUri ?variableType ?variableValue ?variableDefaultValue ?variableCodelist WHERE {
+    SELECT DISTINCT ?uri ?templateValue ?variableUri ?variableType ?variableValue ?variableDefaultValue ?variableCodelist ?annotatedTemplate WHERE {
       ${values}
   
       ?uri a mobiliteit:Template ;
@@ -60,6 +60,10 @@ export const getTemplatesAndVariables = async (templateUris) => {
         }
         OPTIONAL {
           ?variableUri ext:codeList ?variableCodelist .
+        }
+        OPTIONAL {
+          ?variableUri mobiliteit:template ?template.
+          ?template ext:annotated ?annotatedTemplate
         }
       }
     }
@@ -153,4 +157,39 @@ export const deleteAnnotated = async (uris) => {
         `;
 
   await update(deleteQuery);
+};
+
+export const getLinkedTemplates = async (templateUris) => {
+  if (templateUris && !Array.isArray(templateUris)) {
+    throw new Error("templateUris must be an array of strings.");
+  }
+
+  const values = templateUris?.length
+    ? `VALUES ?uri {${templateUris
+        .map((uri) => sparqlEscapeUri(uri))
+        .join(" ")}}`
+    : "";
+
+  const selectTemplateQuery = `
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  
+    SELECT DISTINCT ?linkedTemplateUri WHERE {
+      ${values}
+  
+      ?variableUri mobiliteit:template ?uri.
+      ?linkedTemplateUri mobiliteit:variabele ?variableUri .
+
+      ?uri a mobiliteit:Template ;
+        prov:value ?templateValue .
+    }
+    `;
+
+  const queryResult = await query(selectTemplateQuery);
+  return queryResult.results.bindings.map(
+    (binding) => binding.linkedTemplateUri.value
+  );
 };

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -169,6 +169,10 @@ export const getLinkedTemplates = async (templateUris) => {
   if (templateUris && !Array.isArray(templateUris)) {
     throw new Error("templateUris must be an array of strings.");
   }
+  if (!templateUris.length) {
+    //If there's no uris given we return no template uris linked
+    return [];
+  }
 
   const values = templateUris?.length
     ? `VALUES ?uri {${templateUris


### PR DESCRIPTION
Update the service to also include instructions in the annotations. This means we have to make sure that when we update an instruction all the templates that link that instruction are also up to date, in order to do this, when we receive a delta that update a template we check if there's any template that links to that one, and if so we update them.
Also means that the update all endpoint needs to run twice to ensure a correct result, because if it runs only one it can update some instructions but not the linked templates. This can be done better but it's an endpoint that is not used a lot, so it's not worth it to put more time into it to develop a cleaner solution
