### PR TITLE
variables: replace `rdf:value` by `dct:title`

### DIFF
--- a/lib/process-template-annotation.js
+++ b/lib/process-template-annotation.js
@@ -15,7 +15,7 @@ import {
 /**
  * @typedef {Object} TemplateVariable
  * @property {string} uri - The URI of the variable.
- * @property {string} value - The name of the variable.
+ * @property {string} label - The name of the variable.
  * @property {string} type - The type of the variable.
  * @property {string} [defaultValue] - The default value of the variable (optional).
  * @property {string} [codelist] - The codelist of the variable (optional).
@@ -44,7 +44,7 @@ export const parseSelectTemplateBindings = (bindings) => {
     if (binding.variableUri) {
       const variable = {
         uri: binding.variableUri.value,
-        value: binding.variableValue.value,
+        label: binding.variableLabel.value,
         type: binding.variableType.value,
         ...(binding.variableDefaultValue && {
           defaultValue: binding.variableDefaultValue.value,
@@ -105,7 +105,7 @@ export const applyTemplateMappings = (basicTemplate, variables) => {
     default: generateTextTemplate,
   };
   for (const variable of variables) {
-    const regex = new RegExp(`\\\${${variable.value}}`, "g");
+    const regex = new RegExp(`\\\${${variable.label}}`, "g");
     const generator =
       templateGenerators[variable.type] || templateGenerators.default;
 

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -7,7 +7,7 @@ import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
  * @property {SparqlValue} templateValue - The template value object
  * @property {SparqlValue} [variableUri] - The variable URI object (optional)
  * @property {SparqlValue} [variableType] - The variable type object (optional)
- * @property {SparqlValue} [variableValue] - The variable name object (optional)
+ * @property {SparqlValue} [variableLabel] - The variable name object (optional)
  * @property {SparqlValue} [variableDefaultValue] - The variable default value object (optional)
  * @property {SparqlValue} [variableCodelist] - The variable codelist object (optional)
  */
@@ -44,7 +44,7 @@ export const getTemplatesAndVariables = async (templateUris) => {
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   
-    SELECT DISTINCT ?uri ?templateValue ?variableUri ?variableType ?variableValue ?variableDefaultValue ?variableCodelist ?annotatedTemplate WHERE {
+    SELECT DISTINCT ?uri ?templateValue ?variableUri ?variableType ?variableLabel ?variableDefaultValue ?variableCodelist ?annotatedTemplate WHERE {
       ${values}
   
       ?uri a mobiliteit:Template ;
@@ -53,7 +53,7 @@ export const getTemplatesAndVariables = async (templateUris) => {
       OPTIONAL {
         ?uri mobiliteit:variabele ?variableUri .
         ?variableUri dct:type ?variableType ;
-          rdf:value ?variableValue .
+          dct:title ?variableLabel .
   
         OPTIONAL {
           ?variableUri mobiliteit:standaardwaarde ?variableDefaultValue .

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -3,14 +3,14 @@
  *
  * @param {Object} variable - The object containing the variable data.
  * @param {string} variable.uri - The URI of the variable.
- * @param {string} variable.value - The name of the variable.
+ * @param {string} variable.label - The name of the variable.
  * @param {string} [variable.defaultValue] - The default value of the variable (optional).
  * @returns {string} The text template string.
  */
-export const generateTextTemplate = ({ uri, value, defaultValue }) => {
+export const generateTextTemplate = ({ uri, label, defaultValue }) => {
   return `
     <span resource="${uri}" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-      <span class="mark-highlight-manual" property="rdf:value">\${${value}}</span>
+      <span class="mark-highlight-manual" property="dct:title">\${${label}}</span>
       ${
         !defaultValue?.length
           ? ""
@@ -25,14 +25,14 @@ export const generateTextTemplate = ({ uri, value, defaultValue }) => {
  *
  * @param {Object} variable - The object containing the variable data.
  * @param {string} variable.uri - The URI of the variable.
- * @param {string} variable.value - The name of the variable.
+ * @param {string} variable.label - The name of the variable.
  * @param {string} variable.codelist - The codelist of the variable.
  * @param {string} variable.source - The source of the variable.
  * @param {string} [variable.defaultValue] - The default value of the variable (optional).
  */
 export const generateCodelistTemplate = ({
   uri,
-  value,
+  label,
   codelist,
   source,
   defaultValue,
@@ -42,7 +42,7 @@ export const generateCodelistTemplate = ({
       <span property="dct:type" content="codelist"></span>
       <span property="dct:source" resource="${source}"></span>
       <span property="ext:codelist" resource="${codelist}"></span>
-      <span class="mark-highlight-manual" property="rdf:value">\${${value}}</span>
+      <span class="mark-highlight-manual" property="dct:title">\${${label}}</span>
       ${
         !defaultValue?.length
           ? ""
@@ -57,14 +57,14 @@ export const generateCodelistTemplate = ({
  *
  * @param {Object} variable - The object containing the variable data.
  * @param {string} variable.uri - The URI of the variable.
- * @param {string} variable.value - The name of the variable.
+ * @param {string} variable.label - The name of the variable.
  * @param {string} variable.source - The source of the variable.
  * @param {string} [variable.defaultValue] - The default value of the variable (optional).
  * @returns {string} The location template string.
  */
 export const generateLocationTemplate = ({
   uri,
-  value,
+  label,
   source,
   defaultValue,
 }) => {
@@ -72,7 +72,7 @@ export const generateLocationTemplate = ({
     <span resource="${uri}" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
       <span property="dct:type" content="location"></span>
       <span property="dct:source" resource="${source}"></span>
-      <span class="mark-highlight-manual" property="rdf:value">\${${value}}</span>
+      <span class="mark-highlight-manual" property="dct:title">\${${label}}</span>
       ${
         !defaultValue?.length
           ? ""
@@ -87,15 +87,15 @@ export const generateLocationTemplate = ({
  *
  * @param {Object} variable - The object containing the variable data.
  * @param {string} variable.uri - The URI of the variable.
- * @param {string} variable.value - The name of the variable.
+ * @param {string} variable.label - The name of the variable.
  * @param {string} [variable.defaultValue] - The default value of the variable (optional).
  * @returns {string} The date template string.
  */
-export const generateDateTemplate = ({ uri, value, defaultValue }) => {
+export const generateDateTemplate = ({ uri, label, defaultValue }) => {
   return `
     <span resource="${uri}" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
       <span property="dct:type" content="date"></span>
-      <span class="mark-highlight-manual" property="rdf:value" datatype="xsd:date">\${${value}}</span>
+      <span class="mark-highlight-manual" property="dct:title">\${${label}}</span>
       ${
         !defaultValue?.length
           ? ""

--- a/test/lib/process-template-annotation.test.js
+++ b/test/lib/process-template-annotation.test.js
@@ -24,34 +24,34 @@ const parsedBinding = [
       {
         uri: "http://data.lblod.info/variables/67476E5D5A9960633226D2AF",
         type: "codelist",
-        value: "codelijst",
+        label: "codelijst",
         codelist:
           "http://lblod.data.gift/concept-schemes/63B58F51867176EC5DDD14C9",
       },
       {
         uri: "http://data.lblod.info/variables/67476E5E5A9960633226D2B0",
         type: "date",
-        value: "datum",
+        label: "datum",
       },
       {
         uri: "http://data.lblod.info/variables/67476E5D5A9960633226D2AC",
         type: "location",
-        value: "locatie",
+        label: "locatie",
       },
       {
         uri: "http://data.lblod.info/variables/67476E5D5A9960633226D2AD",
         type: "number",
-        value: "autonummer",
+        label: "autonummer",
       },
       {
         uri: "http://data.lblod.info/variables/67476E5D5A9960633226D2AE",
         type: "text",
-        value: "tekst",
+        label: "tekst",
       },
       {
         uri: "http://data.lblod.info/variables/67476E5E5A9960633226D2B1",
         type: "number",
-        value: "cijferstesten",
+        label: "cijferstesten",
       },
     ],
   },
@@ -71,30 +71,30 @@ const annotatedArray = [
       <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AC" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
         <span property="dct:type" content="location"></span>
         <span property="dct:source" resource="http://example.com/sparql"></span>
-        <span class="mark-highlight-manual" property="rdf:value">\${locatie}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${locatie}</span>
       </span>
       abc,
       <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AD" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-        <span class="mark-highlight-manual" property="rdf:value">\${autonummer}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${autonummer}</span>
       </span>
       dan
       <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AE" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-        <span class="mark-highlight-manual" property="rdf:value">\${tekst}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${tekst}</span>
       </span>
       codelijst van
       <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AF" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
         <span property="dct:type" content="codelist"></span>
         <span property="dct:source" resource="http://example.com/sparql"></span>
         <span property="ext:codelist" resource="http://lblod.data.gift/concept-schemes/63B58F51867176EC5DDD14C9"></span>
-        <span class="mark-highlight-manual" property="rdf:value">\${codelijst}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${codelijst}</span>
       </span>
       en ook nog is een datum eh
       <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B0" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
         <span property="dct:type" content="date"></span>
-        <span class="mark-highlight-manual" property="rdf:value" datatype="xsd:date">\${datum}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${datum}</span>
       </span>
       <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B1" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-        <span class="mark-highlight-manual" property="rdf:value">\${cijferstesten}</span>
+        <span class="mark-highlight-manual" property="dct:title">\${cijferstesten}</span>
       </span>
       `,
   },
@@ -132,25 +132,25 @@ describe("process template annotation", () => {
         variables: [
           {
             uri: "http://data.lblod.info/mappings/6486F5D44E5B47D5A3A1EDE3",
-            value: "locatie",
+            label: "locatie",
             type: "location",
             defaultValue: "Locatie_1",
           },
           {
             uri: "http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE4",
-            value: "autonummer",
+            label: "autonummer",
             type: "number",
             defaultValue: "123",
           },
           {
             uri: "http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE5",
-            value: "tekst",
+            label: "tekst",
             type: "text",
             defaultValue: "Tekst_1",
           },
           {
             uri: "http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE6",
-            value: "codelijst",
+            label: "codelijst",
             type: "codelist",
             codelist:
               "http://lblod.data.gift/concept-schemes/61C054CEE3249100080000B9",
@@ -158,13 +158,13 @@ describe("process template annotation", () => {
           },
           {
             uri: "http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE7",
-            value: "datum",
+            label: "datum",
             type: "date",
             defaultValue: "2021-01-01",
           },
           {
             uri: "http://data.lblod.info/mappings/649D79A34E5B47D5A3A1EE0F",
-            value: "cijferstesten",
+            label: "cijferstesten",
             type: "number",
             defaultValue: "456",
           },
@@ -174,17 +174,17 @@ describe("process template annotation", () => {
         <span resource="http://data.lblod.info/mappings/6486F5D44E5B47D5A3A1EDE3" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
           <span property="dct:type" content="location"></span>  
           <span property="dct:source" resource="http://example.com/sparql"></span>
-          <span class="mark-highlight-manual" property="rdf:value">\${locatie}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${locatie}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde">Locatie_1</span>
         </span>
         abc, 
         <span resource="http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE4" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-          <span class="mark-highlight-manual" property="rdf:value">\${autonummer}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${autonummer}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde">123</span>
         </span>
         dan 
         <span resource="http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE5" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-          <span class="mark-highlight-manual" property="rdf:value">\${tekst}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${tekst}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde">Tekst_1</span>
         </span>
         codelijst van 
@@ -192,18 +192,18 @@ describe("process template annotation", () => {
           <span property="dct:type" content="codelist"></span>   
           <span property="dct:source" resource="http://example.com/sparql"></span>
           <span property="ext:codelist" resource="http://lblod.data.gift/concept-schemes/61C054CEE3249100080000B9"></span>
-          <span class="mark-highlight-manual" property="rdf:value">\${codelijst}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${codelijst}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde">Codelijst_1</span>
         </span>
         en ook nog is een datum eh 
         <span resource="http://data.lblod.info/mappings/6486F5D54E5B47D5A3A1EDE7" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
           <span property="dct:type" content="date"></span>  
-          <span class="mark-highlight-manual" property="rdf:value" datatype="xsd:date">\${datum}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${datum}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde" datatype="xsd:date">2021-01-01</span>
         </span>
         
         <span resource="http://data.lblod.info/mappings/649D79A34E5B47D5A3A1EE0F" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
-          <span class="mark-highlight-manual" property="rdf:value">\${cijferstesten}</span>
+          <span class="mark-highlight-manual" property="dct:title">\${cijferstesten}</span>
           <span property="https://data.vlaanderen.be/ns/mobiliteit#standaardwaarde">456</span>
         </span>`;
       const result = applyTemplateMappings(

--- a/test/lib/process-template-annotation.test.js
+++ b/test/lib/process-template-annotation.test.js
@@ -67,7 +67,36 @@ const annotatedArray = [
   {
     uri: "http://data.lblod.info/templates/67476E5D5A9960633226D2AB",
     annotated:
-      '\n    <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AC" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span property="dct:type" content="location"></span>\n      <span property="dct:source" resource="http://example.com/sparql"></span>\n      <span class="mark-highlight-manual" property="rdf:value">${locatie}</span>\n      \n    </span>\n   abc, \n    <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AD" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span class="mark-highlight-manual" property="rdf:value">${autonummer}</span>\n      \n    </span>\n   dan \n    <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AE" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span class="mark-highlight-manual" property="rdf:value">${tekst}</span>\n      \n    </span>\n   codelijst van \n    <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AF" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span property="dct:type" content="codelist"></span>\n      <span property="dct:source" resource="http://example.com/sparql"></span>\n      <span property="ext:codelist" resource="http://lblod.data.gift/concept-schemes/63B58F51867176EC5DDD14C9"></span>\n      <span class="mark-highlight-manual" property="rdf:value">${codelijst}</span>\n      \n    </span>\n   en ook nog is een datum eh \n    <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B0" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span property="dct:type" content="date"></span>\n      <span class="mark-highlight-manual" property="rdf:value" datatype="xsd:date">${datum}</span>\n      \n    </span>\n   \n    <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B1" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">\n      <span class="mark-highlight-manual" property="rdf:value">${cijferstesten}</span>\n      \n    </span>\n  ',
+      `
+      <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AC" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span property="dct:type" content="location"></span>
+        <span property="dct:source" resource="http://example.com/sparql"></span>
+        <span class="mark-highlight-manual" property="rdf:value">\${locatie}</span>
+      </span>
+      abc,
+      <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AD" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span class="mark-highlight-manual" property="rdf:value">\${autonummer}</span>
+      </span>
+      dan
+      <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AE" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span class="mark-highlight-manual" property="rdf:value">\${tekst}</span>
+      </span>
+      codelijst van
+      <span resource="http://data.lblod.info/variables/67476E5D5A9960633226D2AF" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span property="dct:type" content="codelist"></span>
+        <span property="dct:source" resource="http://example.com/sparql"></span>
+        <span property="ext:codelist" resource="http://lblod.data.gift/concept-schemes/63B58F51867176EC5DDD14C9"></span>
+        <span class="mark-highlight-manual" property="rdf:value">\${codelijst}</span>
+      </span>
+      en ook nog is een datum eh
+      <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B0" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span property="dct:type" content="date"></span>
+        <span class="mark-highlight-manual" property="rdf:value" datatype="xsd:date">\${datum}</span>
+      </span>
+      <span resource="http://data.lblod.info/variables/67476E5E5A9960633226D2B1" typeof="https://data.vlaanderen.be/ns/mobiliteit#Variabele">
+        <span class="mark-highlight-manual" property="rdf:value">\${cijferstesten}</span>
+      </span>
+      `,
   },
   {
     uri: "http://data.lblod.info/templates/643003B35BDCDA240120BDCB",
@@ -188,8 +217,8 @@ describe("process template annotation", () => {
   describe("generateAnnotatedArray", () => {
     it("should generate annotated array", () => {
       const data = parsedBinding;
-      const expected = annotatedArray;
-      const result = generateAnnotatedTemplates(data);
+      const expected = annotatedArray.map((entry) => { return {...entry, annotated: normalize(entry.annotated)} });
+      const result = generateAnnotatedTemplates(data).map((entry) => { return {...entry, annotated: normalize(entry.annotated)} });
       assert.deepStrictEqual(result, expected);
     });
   });

--- a/test/mocks/select-template-response.js
+++ b/test/mocks/select-template-response.js
@@ -4,7 +4,7 @@ const RESPONSE  = {
     "distinct": false,
     "bindings": [
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "codelijst",
           "type": "literal"
         },
@@ -30,7 +30,7 @@ const RESPONSE  = {
         }
       },
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "datum",
           "type": "literal"
         },
@@ -52,7 +52,7 @@ const RESPONSE  = {
         }
       },
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "locatie",
           "type": "literal"
         },
@@ -74,7 +74,7 @@ const RESPONSE  = {
         }
       },
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "autonummer",
           "type": "literal"
         },
@@ -96,7 +96,7 @@ const RESPONSE  = {
         }
       },
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "tekst",
           "type": "literal"
         },
@@ -118,7 +118,7 @@ const RESPONSE  = {
         }
       },
       {
-        "variableValue": {
+        "variableLabel": {
           "value": "cijferstesten",
           "type": "literal"
         },
@@ -157,7 +157,7 @@ const RESPONSE  = {
       "templateValue",
       "variableUri",
       "variableType",
-      "variableValue",
+      "variableLabel",
       "variableDefaultValue",
       "variableCodelist"
     ],


### PR DESCRIPTION
### Overview
This PR includes some changes in how variables are processed/treated:
- The `rdf:value` predicate has been replaced by `dct:title` as it is more appropriate for the label/title of a variable. 

Additionally, I also did some reformatting of the html used in the unit tests for readability.
##### connected issues and PRs:
https://github.com/lblod/frontend-mow-registry/pull/314
https://github.com/lblod/app-mow-registry/pull/108

### How to test/reproduce
Check-out https://github.com/lblod/app-mow-registry/pull/108

### Checks PR readines
- [x] changelog
- [x] npm lint
