### PR TITLE
Use correct `rdf:value` predicate for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example `delta-notifier` configuration:
   match: {
     predicate: {
       type: 'uri',
-      value: 'http://www.w3.org/ns/prov#value'
+      value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value'
     }
   },
   callback: {

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -39,7 +39,6 @@ export const getTemplatesAndVariables = async (templateUris) => {
   const selectTemplateQuery = `
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   
@@ -47,7 +46,7 @@ export const getTemplatesAndVariables = async (templateUris) => {
       ${values}
   
       ?uri a mobiliteit:Template ;
-        prov:value ?templateValue .
+        rdf:value ?templateValue .
   
       OPTIONAL {
         ?uri mobiliteit:variabele ?variableUri .
@@ -175,7 +174,6 @@ export const getLinkedTemplates = async (templateUris) => {
   const selectTemplateQuery = `
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   
@@ -186,7 +184,7 @@ export const getLinkedTemplates = async (templateUris) => {
       ?linkedTemplateUri mobiliteit:variabele ?variableUri .
 
       ?uri a mobiliteit:Template ;
-        prov:value ?templateValue .
+        rdf:value ?templateValue .
     }
     `;
 

--- a/test/mocks/delta.js
+++ b/test/mocks/delta.js
@@ -7,7 +7,7 @@ export const updateOne = [
           value: "http://data.lblod.info/templates/61B33386BF5C7500090006E7",
           type: "uri",
         },
-        predicate: { value: "http://www.w3.org/ns/prov#value", type: "uri" },
+        predicate: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", type: "uri" },
         object: {
           value:
             "${locatie} \n${B1}; \n${M10};\n${GVIII};\n${WM76.2}.\n${locatie2} \n${B9}.\n${locatie3} \n${B11}.",
@@ -24,7 +24,7 @@ export const updateOne = [
           value: "http://data.lblod.info/templates/61B33386BF5C7500090006E7",
           type: "uri",
         },
-        predicate: { value: "http://www.w3.org/ns/prov#value", type: "uri" },
+        predicate: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", type: "uri" },
         object: {
           value:
             "${locatie} \\n${B1}; \\n${M10};\\n${GVIII};\\n${WM76.2}.\\n${locatie2} \\n${B9}.\\n${locatie3} \\n${B11}.",
@@ -46,7 +46,7 @@ export const deleteOne = [
           value: "http://data.lblod.info/templates/61B33386BF5C7500090006E7",
           type: "uri",
         },
-        predicate: { value: "http://www.w3.org/ns/prov#value", type: "uri" },
+        predicate: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", type: "uri" },
         object: {
           value:
             "${locatie} \n${B1}; \n${M10};\n${GVIII};\n${WM76.2}.\n${locatie2} \n${B9}.\n${locatie3} \n${B11}.",
@@ -74,7 +74,7 @@ export const multipleInsertWithDuplicateSubject = [
           value: "http://data.lblod.info/templates/61B33386BF5C7500090006E7",
           type: "uri",
         },
-        predicate: { value: "http://www.w3.org/ns/prov#value", type: "uri" },
+        predicate: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", type: "uri" },
         object: {
           value:
             "${locatie} \n${B1}; \n${M10};\n${GVIII};\n${WM76.2}.\n${locatie2} \n${B9}.\n${locatie3} \n${B11}.",
@@ -87,7 +87,7 @@ export const multipleInsertWithDuplicateSubject = [
           value: "http://data.lblod.info/templates/61B33386BF5C7500090006E7",
           type: "uri",
         },
-        predicate: { value: "http://www.w3.org/ns/prov#value", type: "uri" },
+        predicate: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", type: "uri" },
         object: {
           value:
             "${locatie} \n${B1}; \n${M10};\n${GVIII};\n${WM76.2}.\n${locatie2} \n${B9}.\n${locatie3} \n${B11}.",


### PR DESCRIPTION
### Overview
This PR ensures that this services used the correct `rdf:value` predicate to retrieve the value of templates (coming from `prov:value`)

##### connected issues and PRs:
https://github.com/lblod/app-mow-registry/pull/111

### How to test/reproduce
Check-out https://github.com/lblod/app-mow-registry/pull/111

### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
