### PR TITLE
Handle deltas with no updates without processing all templates

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -29,6 +29,9 @@ export const getTemplatesAndVariables = async (templateUris) => {
   if (templateUris && !Array.isArray(templateUris)) {
     throw new Error("templateUris must be an array of strings.");
   }
+  if (templateUris && !templateUris.length) {
+    return { results: { bindings: [] } };
+  }
 
   const values = templateUris?.length
     ? `VALUES ?uri {${templateUris


### PR DESCRIPTION
Deltas with no updates, e.g. deletes, were resulting in a query that inadvertently included all templates, which would then be updated. This resulted in thousands of updates for every delete...

Discovered while investigating https://binnenland.atlassian.net/browse/GN-5637

### Testing

This is easiest seen on [a version of the frontend which deletes more of the related triples](https://github.com/lblod/frontend-mow-registry/pull/328) when deleting a sign. Create a sign, then, while looking at the sparql-parser logs, delete it. Without this fix, you should see a huge amount of logging. With the fix, this should not happen.